### PR TITLE
Use field mapping types for excel to pdf

### DIFF
--- a/procedure_generator/config_loader.py
+++ b/procedure_generator/config_loader.py
@@ -56,8 +56,13 @@ class ExcelToPDFProcessingConfig(BaseModel):
     default_sheet_name: str = ""
 
 
+class FieldMappingConfig(BaseModel):
+    pdf_field: str
+    type: str = "text"
+
+
 class ExcelToPDFConfig(BaseModel):
-    field_mappings: Dict[str, str] = Field(default_factory=dict)
+    field_mappings: Dict[str, FieldMappingConfig] = Field(default_factory=dict)
     processing: ExcelToPDFProcessingConfig = Field(default_factory=ExcelToPDFProcessingConfig)
 
 

--- a/procedure_generator/excel_pdf/excel_pdf.py
+++ b/procedure_generator/excel_pdf/excel_pdf.py
@@ -1,7 +1,7 @@
+import argparse
+from typing import Optional
 import pandas as pd
 from fillpdf import fillpdfs
-from typing import Optional
-import argparse
 from ..config_loader import config
 
 def excel_pdf(excel_file: str, pdf_template: str, output_pdf: str):

--- a/procedure_generator/excel_pdf/excel_pdf.py
+++ b/procedure_generator/excel_pdf/excel_pdf.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from fillpdf import fillpdfs
 from typing import Optional
+import argparse
 from ..config_loader import config
 
 def excel_pdf(excel_file: str, pdf_template: str, output_pdf: str):
@@ -30,16 +31,38 @@ def excel_pdf(excel_file: str, pdf_template: str, output_pdf: str):
         # Always trim whitespace
         excel_field_clean = str(excel_field).strip()
         
-        pdf_field = None
-        for config_excel_field, config_pdf_field in field_map.items():
+        # Find matching field mapping
+        field_config = None
+        for config_excel_field, mapping_config in field_map.items():
             if config_excel_field.lower() == excel_field_clean.lower():
-                pdf_field = config_pdf_field
+                field_config = mapping_config
                 break
         
-        if pdf_field:
+        if field_config:
+            # Extract PDF field name and type from Pydantic model
+            try:
+                pdf_field = field_config.pdf_field
+                field_type = field_config.type
+                
+                if not pdf_field:
+                    print(f"Warning: No pdf_field specified for '{excel_field}' in configuration")
+                    continue
+            except AttributeError:
+                print(f"Warning: Invalid configuration format for '{excel_field}' - missing required attributes")
+                continue
+            
             # Always trim value if it's a string
             if isinstance(value, str):
                 value = value.strip()
+            
+            # Handle checkbox values - only convert if field type is checkbox
+            if field_type == "checkbox" and isinstance(value, str):
+                value_lower = value.lower()
+                if value_lower in ["yes", "true", "1", "on"]:
+                    value = 'Yes'
+                elif value_lower in ["no", "false", "0", "off"]:
+                    value = 'Off'
+            
             pdf_data[str(pdf_field).strip()] = value
 
     # Fill the PDF
@@ -47,3 +70,22 @@ def excel_pdf(excel_file: str, pdf_template: str, output_pdf: str):
 
     print(f"\nFilled PDF saved as: {output_pdf}")
     print(f"Mapped {len(pdf_data)} fields from Excel to PDF")
+
+def main():
+    parser = argparse.ArgumentParser(description='Fill PDF form from Excel data')
+    parser.add_argument('excel_file', help='Path to the Excel file')
+    parser.add_argument('pdf_template', help='Path to the PDF template file')
+    parser.add_argument('output_pdf', help='Path for the output PDF file')
+    
+    args = parser.parse_args()
+    
+    try:
+        excel_pdf(args.excel_file, args.pdf_template, args.output_pdf)
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+    
+    return 0
+
+if __name__ == "__main__":
+    exit(main())

--- a/procedure_generator/swp_config.yaml
+++ b/procedure_generator/swp_config.yaml
@@ -243,15 +243,24 @@ NOP:
 
 # Excel to PDF conversion configuration
 EXCEL_TO_PDF:
-  # Mapping from Excel column names to PDF field names
-  # Format: "Excel Column Name": "PDF Field Name"
+  # Mapping from Excel names to PDF field names with field types
+  # Format: Excel name with pdf_field and type properties
   field_mappings:
-    "Name": "FullName"
-    "Address": "StreetAddress"
-    "Phone": "PhoneNumber"
-    "Province": "Region"
-    "Job Title": "JobTitle"
-    "Department": "Dept"
+    Name:
+      pdf_field: FullName
+    Address:
+      pdf_field: StreetAddress
+    Phone:
+      pdf_field: PhoneNumber
+    Province:
+      pdf_field: Region
+    Job Title:
+      pdf_field: JobTitle
+    Department:
+      pdf_field: Dept
+    Asbestos:
+      pdf_field: Asbestos Check
+      type: checkbox
   
   # Configuration for Excel file processing
   processing:


### PR DESCRIPTION
This pull request refactors the Excel-to-PDF mapping logic to support more complex field configurations, introduces a command-line interface for the script, and updates the configuration file format to align with the changes. The most important changes include adding support for field types (e.g., checkboxes), implementing a CLI entry point, and updating the configuration schema.